### PR TITLE
A bit of adjustments on what I lined out

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -998,8 +998,13 @@ class VlsvReader(object):
                return data_operators[operator](data)
       
       # Check which set of datareducers to use
-      if varname in deprecated_datareducers.keys():         
-         raise KeyError(deprecated_datareducers[varname] )
+      if '/' in name and popname in self.active_populations:
+         checkname = 'pop/'+varname
+      else:
+         checkname = varname
+
+      if checkname in deprecated_datareducers.keys():
+         raise ValueError(deprecated_datareducers[checkname] )
 
       if varname[0:3]=="vg_" or varname[0:3]=="ig_":
          reducer_reg = v5reducers


### PR DESCRIPTION
Added handling of pop/ reducers - varname was split before, and used the same ValueError as when a datareducer is missing (raising KeyError with a line that indexing a dict with an existing key was just a... weird idea..)